### PR TITLE
Fix/server timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,13 @@ If you want to update your domain, you can do so by following the Vercel documen
 
 #### Environment variables
 
-|KEY|VALUE|DEFAULT|DESCRIPTION|
-|-|-|-|-|
-|MOSQUE_API_ENDPOINT|https://api.mosque.tech/mosque-data/1o9dngtGJbfkFGZK_M7xdlo2PtRuQknGEQU3FxpiPVbg|REQUIRED - NO DEFAULT|Data from Mosque API|
-|BLACKOUT_PERIOD|13|13 minutes|How long your mosque screen dims / blacks out during congregation prayer|
-|UPCOMING_PRAYER_DAY|3|3 upcoming days shown in slider|How many upcoming days it shows in the sliding section|
-|SLIDE_TRANSITION_TIME|7|7 seconds|How long each slide shows for in the sliding section|
+| KEY                   | VALUE                                                                            | DEFAULT                         | DESCRIPTION                                                                                                                                                       |
+|-----------------------|----------------------------------------------------------------------------------|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| MOSQUE_API_ENDPOINT   | https://api.mosque.tech/mosque-data/1o9dngtGJbfkFGZK_M7xdlo2PtRuQknGEQU3FxpiPVbg | REQUIRED - NO DEFAULT           | Data from Mosque API                                                                                                                                              |
+| BLACKOUT_PERIOD       | 13                                                                               | 13 minutes                      | How long your mosque screen dims / blacks out during congregation prayer                                                                                          |
+| UPCOMING_PRAYER_DAY   | 3                                                                                | 3 upcoming days shown in slider | How many upcoming days it shows in the sliding section                                                                                                            |
+| SLIDE_TRANSITION_TIME | 7                                                                                | 7 seconds                       | How long each slide shows for in the sliding section                                                                                                              |
+| TIMEZONE              | Australia/Melbourne                                                              | UTC                             | Timezone for local mosque. Used in server side date calculations. Required if your location is not UTC to avoid the incorrect date's prayer times being displayed |
 
 ## Dev set up
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
         "moment-hijri": "^2.1.2",
+        "moment-timezone": "^0.5.45",
         "next": "^13.5.6",
         "postcss": "^8.4.31",
         "react": "18.2.0",
@@ -2740,6 +2741,17 @@
       "integrity": "sha512-p5ZOA1UzBHAAXiePh37XRjjwuyH78+1ShYZ7R6jogxketewG7kTCUjUmcP9c4Qsx8D8cqxwUWrESjtgdT6tNoA==",
       "dependencies": {
         "moment": "^2.24.0"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.45",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lodash": "^4.17.21",
     "moment": "^2.29.4",
     "moment-hijri": "^2.1.2",
+    "moment-timezone": "^0.5.45",
     "next": "^13.5.6",
     "postcss": "^8.4.31",
     "react": "18.2.0",

--- a/services/MosqueDataService.ts
+++ b/services/MosqueDataService.ts
@@ -5,10 +5,22 @@ import {
 import { JummahTimes } from "@/types/JummahTimesType"
 import { MosqueMetadataType, MosqueData } from "@/types/MosqueDataType"
 import { find } from "lodash"
-import moment from "moment"
+import moment from "moment-timezone"
 
 const MOSQUE_API_ENDPOINT = process.env.MOSQUE_API_ENDPOINT ?? ""
 const DAY_FOR_UPCOMING = parseInt(process.env?.UPCOMING_PRAYER_DAY ?? "3")
+const timeZone = process.env.TIMEZONE ?? ""
+
+// set prayer time calculations to mosque local timezone
+// needs to be IANA TZ identifier
+// this is just needed in server side components.
+// display device should already be in local timezone
+if ( timeZone && !!moment.tz.zone(timeZone)) {
+  moment.tz.setDefault(timeZone)
+} else {
+  console.warn("Invalid timezone identifier")
+}
+
 
 export async function getMosqueData(): Promise<MosqueData> {
   const response = await fetch(MOSQUE_API_ENDPOINT, {


### PR DESCRIPTION
fix for  #31 - prayer times are selected for the wrong date 
- particularly obvious when there is a large gap between UTC/local time and around daylight saving days.

added  TIMEZONE option to environment variables and uses `moment-timezone` in MosqueDataService (server side) to set the date according to that timezone
